### PR TITLE
Fixed a typo in the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SMTP-MAIL
 Making it easy to send SMTP emails from Haskell.
 
 ```
-cabal install smtp-email
+cabal install smtp-mail
 ```
 
 ### Sending with an SMTP server


### PR DESCRIPTION
This is just a typo that annoyed me for a few seconds while trying to install the library using `cabal install`.
