### PR TITLE
Fall back to HELO if EHLO is not supported

### DIFF
--- a/smtp-mail.cabal
+++ b/smtp-mail.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                smtp-mail
-version:             0.1.4.3
+version:             0.1.4.4
 synopsis:            Simple email sending via SMTP
 -- description:         
 homepage:            http://github.com/jhickner/smtp-mail


### PR DESCRIPTION
Hi Jason,

Here is a patch which allows the client to fall back to HELO if EHLO is not supported. Could you please push this to Hackage ASAP?

Thanks,
Victor.
