### PR TITLE
Also pass Cc and Bcc addresses to the smtp server

### DIFF
--- a/Network/Mail/SMTP.hs
+++ b/Network/Mail/SMTP.hs
@@ -232,7 +232,7 @@ renderAndSend conn mail@Mail{..} = do
     sendRenderedMail from to rendered conn
   where enc  = encodeUtf8 . addressEmail
         from = enc mailFrom
-        to   = map enc mailTo
+        to   = map enc $ mailTo ++ mailCc ++ mailBcc
 
 -- | Connect to an SMTP server, send a 'Mail', then disconnect.  Uses the default port (25).
 sendMail :: HostName -> Mail -> IO ()
@@ -283,7 +283,7 @@ renderAndSendFrom sender conn mail@Mail{..} = do
     rendered <- BL.toStrict `fmap` renderMail' mail
     sendRenderedMail sender to rendered conn
   where enc  = encodeUtf8 . addressEmail
-        to   = map enc mailTo
+        to   = map enc $ mailTo ++ mailCc ++ mailBcc
 
 -- | A convenience function that sends 'AUTH' 'LOGIN' to the server
 login :: SMTPConnection -> UserName -> Password -> IO (ReplyCode, ByteString)


### PR DESCRIPTION
Currently, an encoded mail can contain addresses in all of the To, Cc, and Bcc fields, but only the To addresses are passed to the SMTP server upon send, meaning that the addresses in the Cc and Bcc fields will not be sent the message. I believe the correct thing to do is pass all three lists of addresses to the SMTP server, that way all recipients will be sent a copy of the mail, and the mime encoding of the three fields, within the message itself, will ensure that the receiving email clients will treat them correctly.