### PR TITLE
Replace deprecated Network usage

### DIFF
--- a/Network/Mail/SMTP.hs
+++ b/Network/Mail/SMTP.hs
@@ -72,8 +72,8 @@ connectSMTP' :: HostName     -- ^ name of the server
              -> PortNumber -- ^ port number
              -> IO SMTPConnection
 connectSMTP' hostname port = do
-  context <- Conn.initConnectionContext
-  Conn.connectTo context connParams >>= connectStream getHostName
+    context <- Conn.initConnectionContext
+    Conn.connectTo context connParams >>= connectStream getHostName
   where
     connParams = Conn.ConnectionParams hostname port Nothing Nothing
 
@@ -84,8 +84,8 @@ connectSMTPWithHostName :: HostName     -- ^ name of the server
                         -> IO String -- ^ Returns the host name to use to send from
                         -> IO SMTPConnection
 connectSMTPWithHostName hostname port getMailHostName = do
-  context <- Conn.initConnectionContext
-  Conn.connectTo context connParams >>= connectStream getMailHostName
+    context <- Conn.initConnectionContext
+    Conn.connectTo context connParams >>= connectStream getMailHostName
   where
     connParams = Conn.ConnectionParams hostname port Nothing Nothing
 
@@ -134,11 +134,10 @@ connectStream getMailHostName st = do
 
 parseResponse :: Conn.Connection -> IO (ReplyCode, ByteString)
 parseResponse conn = do
-  (code, bdy) <- readLines
-  return (read $ B8.unpack code, B8.unlines bdy)
+    (code, bdy) <- readLines
+    return (read $ B8.unpack code, B8.unlines bdy)
   where
     readLines = do
-      -- TODO: catch exception if line limit is reached
       l <- Conn.connectionGetLine (16 * 1024) conn
       let (c, bdy) = B8.span isDigit l
       if not (B8.null bdy) && B8.head bdy == '-'
@@ -324,5 +323,8 @@ htmlPart body = Part "text/html; charset=utf-8"
 lazyToStrict :: BL.ByteString -> B.ByteString
 lazyToStrict = B.concat . BL.toChunks
 
+crlf :: B8.ByteString
+crlf = B8.pack "\r\n"
+
 bsPutCrLf :: Conn.Connection -> ByteString -> IO ()
-bsPutCrLf = Conn.connectionPut
+bsPutCrLf conn = Conn.connectionPut conn . flip B.append crlf

--- a/Network/Mail/SMTP.hs
+++ b/Network/Mail/SMTP.hs
@@ -137,8 +137,14 @@ parseResponse conn = do
     (code, bdy) <- readLines
     return (read $ B8.unpack code, B8.unlines bdy)
   where
+    getLines c acc = do
+      res <- Conn.connectionGetChunk c
+      if B8.null res
+         then return acc
+         else getLines c $ B8.append acc res
+
     readLines = do
-      l <- Conn.connectionGetLine (16 * 1024) conn
+      l <- getLines conn B8.empty
       let (c, bdy) = B8.span isDigit l
       if not (B8.null bdy) && B8.head bdy == '-'
          then do (c2, ls) <- readLines

--- a/Network/Mail/SMTP.hs
+++ b/Network/Mail/SMTP.hs
@@ -40,16 +40,13 @@ module Network.Mail.SMTP
 import Network.Mail.SMTP.Auth
 import Network.Mail.SMTP.Types
 
-import System.IO
-import System.FilePath (takeFileName)
-
 import Control.Monad (unless)
-import Data.Monoid
 import Data.Char (isDigit)
 
-import Network
+import Network.Socket
 import Network.BSD (getHostName)
 import Network.Mail.Mime hiding (htmlPart, simpleMail)
+import qualified Network.Connection as Conn
 
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
@@ -60,10 +57,10 @@ import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TL
 import Data.Text.Encoding
 
-data SMTPConnection = SMTPC !Handle ![ByteString]
+data SMTPConnection = SMTPC !Conn.Connection ![ByteString]
 
 instance Eq SMTPConnection where
-    (==) (SMTPC a _) (SMTPC b _) = a == b
+    (==) (SMTPC a _) (SMTPC b _) = Conn.connectionID a == Conn.connectionID b
 
 -- | Connect to an SMTP server with the specified host and default port (25)
 connectSMTP :: HostName     -- ^ name of the server
@@ -74,8 +71,11 @@ connectSMTP hostname = connectSMTP' hostname 25
 connectSMTP' :: HostName     -- ^ name of the server
              -> PortNumber -- ^ port number
              -> IO SMTPConnection
-connectSMTP' hostname port =
-    connectTo hostname (PortNumber port) >>= connectStream getHostName
+connectSMTP' hostname port = do
+  context <- Conn.initConnectionContext
+  Conn.connectTo context connParams >>= connectStream getHostName
+  where
+    connParams = Conn.ConnectionParams hostname port Nothing Nothing
 
 
 -- | Connect to an SMTP server with the specified host and port
@@ -83,8 +83,11 @@ connectSMTPWithHostName :: HostName     -- ^ name of the server
                         -> PortNumber -- ^ port number
                         -> IO String -- ^ Returns the host name to use to send from
                         -> IO SMTPConnection
-connectSMTPWithHostName hostname port getMailHostName =
-    connectTo hostname (PortNumber port) >>= connectStream getMailHostName
+connectSMTPWithHostName hostname port getMailHostName = do
+  context <- Conn.initConnectionContext
+  Conn.connectTo context connParams >>= connectStream getMailHostName
+  where
+    connParams = Conn.ConnectionParams hostname port Nothing Nothing
 
 
 -- | Attemp to send a 'Command' to the SMTP server once
@@ -115,11 +118,11 @@ tryCommandNoFail tries st cmd expectedReply = do
       else return (code, msg)
 
 -- | Create an 'SMTPConnection' from an already connected Handle
-connectStream :: IO String -> Handle -> IO SMTPConnection
+connectStream :: IO String -> Conn.Connection -> IO SMTPConnection
 connectStream getMailHostName st = do
     (code1, _) <- parseResponse st
     unless (code1 == 220) $ do
-        hClose st
+        Conn.connectionClose st
         fail "cannot connect to the server"
     senderHost <- getMailHostName
     (code, initialMsg) <- tryCommandNoFail 3 (SMTPC st []) (EHLO $ B8.pack senderHost) 250
@@ -129,18 +132,19 @@ connectStream getMailHostName st = do
         msg <- tryCommand 3 (SMTPC st []) (HELO $ B8.pack senderHost) 250
         return (SMTPC st (tail $ B8.lines msg))
 
-parseResponse :: Handle -> IO (ReplyCode, ByteString)
-parseResponse st = do
-    (code, bdy) <- readLines
-    return (read $ B8.unpack code, B8.unlines bdy)
+parseResponse :: Conn.Connection -> IO (ReplyCode, ByteString)
+parseResponse conn = do
+  (code, bdy) <- readLines
+  return (read $ B8.unpack code, B8.unlines bdy)
   where
     readLines = do
-        l <- B8.hGetLine st
-        let (c, bdy) = B8.span isDigit l
-        if not (B8.null bdy) && B8.head bdy == '-'
-           then do (c2, ls) <- readLines
-                   return (c2, B8.tail bdy:ls)
-           else return (c, [B8.tail bdy])
+      -- TODO: catch exception if line limit is reached
+      l <- Conn.connectionGetLine (16 * 1024) conn
+      let (c, bdy) = B8.span isDigit l
+      if not (B8.null bdy) && B8.head bdy == '-'
+         then do (c2, ls) <- readLines
+                 return (c2, B8.tail bdy:ls)
+         else return (c, [B8.tail bdy])
 
 
 -- | Send a 'Command' to the SMTP server
@@ -210,7 +214,7 @@ sendCommand (SMTPC conn _) meth = do
 
 -- | Send 'QUIT' and close the connection.
 closeSMTP :: SMTPConnection -> IO ()
-closeSMTP c@(SMTPC conn _) = sendCommand c QUIT >> hClose conn
+closeSMTP c@(SMTPC conn _) = sendCommand c QUIT >> Conn.connectionClose conn
 
 -- | Sends a rendered mail to the server.
 sendRenderedMail :: ByteString   -- ^ sender mail
@@ -309,27 +313,16 @@ simpleMail from to cc bcc subject parts =
 
 -- | Construct a plain text 'Part'
 plainTextPart :: TL.Text -> Part
-plainTextPart = Part "text/plain; charset=utf-8"
-              QuotedPrintableText Nothing [] . TL.encodeUtf8
+plainTextPart body = Part "text/plain; charset=utf-8"
+              QuotedPrintableText DefaultDisposition [] (PartContent $ TL.encodeUtf8 body)
 
 -- | Construct an html 'Part'
 htmlPart :: TL.Text -> Part
-htmlPart = Part "text/html; charset=utf-8"
-             QuotedPrintableText Nothing [] . TL.encodeUtf8
-
--- | Construct a file attachment 'Part'
-filePart :: T.Text -- ^ content type
-         -> FilePath -- ^ path to file
-         -> IO Part
-filePart ct fp = do
-    content <- BL.readFile fp
-    return $ Part ct Base64 (Just $ T.pack (takeFileName fp)) [] content
+htmlPart body = Part "text/html; charset=utf-8"
+             QuotedPrintableText DefaultDisposition [] (PartContent $ TL.encodeUtf8 body)
 
 lazyToStrict :: BL.ByteString -> B.ByteString
 lazyToStrict = B.concat . BL.toChunks
 
-crlf :: B8.ByteString
-crlf = B8.pack "\r\n"
-
-bsPutCrLf :: Handle -> ByteString -> IO ()
-bsPutCrLf h s = B8.hPut h s >> B8.hPut h crlf >> hFlush h
+bsPutCrLf :: Conn.Connection -> ByteString -> IO ()
+bsPutCrLf = Conn.connectionPut

--- a/Network/Mail/SMTP/Auth.hs
+++ b/Network/Mail/SMTP/Auth.hs
@@ -13,7 +13,6 @@ import qualified Data.ByteString.Base64 as B64  (encode)
 import Data.ByteString  (ByteString)
 import Data.List
 import Data.Bits
-import Data.Monoid
 import qualified Data.ByteString       as B
 import qualified Data.ByteString.Char8 as B8    (unwords)
 

--- a/smtp-mail.cabal
+++ b/smtp-mail.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                smtp-mail
-version:             0.1.4.6
+version:             0.1.4.7
 synopsis:            Simple email sending via SMTP
 -- description:
 homepage:            http://github.com/jhickner/smtp-mail
@@ -36,6 +36,7 @@ library
                , filepath
                , mime-mail
                , network
+               , network-bsd
                , text
 
   ghc-options: -Wall -fwarn-tabs

--- a/smtp-mail.cabal
+++ b/smtp-mail.cabal
@@ -32,10 +32,11 @@ library
                , base16-bytestring
                , base64-bytestring
                , bytestring
+               , connection
                , cryptohash
                , filepath
                , mime-mail
-               , network
+               , network == 3.0.1.1
                , network-bsd
                , text
 

--- a/smtp-mail.cabal
+++ b/smtp-mail.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                smtp-mail
-version:             0.1.4.7
+version:             0.2.0.0
 synopsis:            Simple email sending via SMTP
 -- description:
 homepage:            http://github.com/jhickner/smtp-mail
@@ -36,7 +36,7 @@ library
                , cryptohash
                , filepath
                , mime-mail
-               , network == 3.0.1.1
+               , network
                , network-bsd
                , text
 


### PR DESCRIPTION
This PR removes the use of deprecated `Network` module (from `network`). Unfortunately there are breaking changes but they are pretty easy to fix (only change of types).

It is still work in progress but I like to get an early feedback if this is the way going forward. I am using this at work, so preferably we like to get this merged at some point when this PR is ready (should be soon).